### PR TITLE
add note about leaks to CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 1. Keep it fun. We're doing serious, at times painstaking, work to make the site incredible, but we can have fun in the process. Summon your best self. Bring a smile.
-2. Differences of opinion are bound to arise. Always give the benefit of the doubt and proceed with kindness. (To put it another way, “Take the high road.”)
-3. Maintain professionalism with one another, the wider King Gizzard fan community, and members of the band’s organization. It is required to receive explicit agreement from team leaders before using the KGLW.net name in community or band outreach.
-4. You agree to protect the artistic and financial interests of the band (and associated acts) by not associating the KGLW.net name with leaks or unauthorized materials.
-5. Remember that everyone here is a volunteer, sharing their time, talent, and expertise, because just like you, they love this amazing band and what it stands for. Respect, both for yourself and for one another, is paramount.
-6. To riff on something the band projects before their concerts: Look after each other in here.
-7. If you have concerns, questions, or feedback about your experience as a member of this team, please reach out to Altered Beef, Rattle, or a team member you feel comfortable dialoguing with.
+1. Differences of opinion are bound to arise. Always give the benefit of the doubt and proceed with kindness. (To put it another way, “Take the high road.”)
+1. Maintain professionalism with one another, the wider King Gizzard fan community, and members of the band’s organization. It is required to receive explicit agreement from team leaders before using the KGLW.net name in community or band outreach.
+1. You agree to protect the artistic and financial interests of the band (and associated acts) by not associating the KGLW.net name with leaks or unauthorized materials.
+1. Remember that everyone here is a volunteer, sharing their time, talent, and expertise, because just like you, they love this amazing band and what it stands for. Respect, both for yourself and for one another, is paramount.
+1. To riff on something the band projects before their concerts: Look after each other in here.
+1. If you have concerns, questions, or feedback about your experience as a member of this team, please reach out to Altered Beef, Rattle, or a team member you feel comfortable dialoguing with.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 1. Keep it fun. We're doing serious, at times painstaking, work to make the site incredible, but we can have fun in the process. Summon your best self. Bring a smile.
 2. Differences of opinion are bound to arise. Always give the benefit of the doubt and proceed with kindness. (To put it another way, “Take the high road.”)
 3. Maintain professionalism with one another, the wider KGLW fan community, and members of the band’s organization. Express agreement from team leaders is required when utilizing the kglw.net namesake in community or band outreach.
-4. Remember that everyone here is a volunteer, sharing their time, talent, and expertise because, just like you, they love this amazing band and what it stands for. Respect, both for yourself and for one another, is paramount.
-5. To riff on something the band projects before their concerts: Look after each other in here.
-6: If you have concerns, questions, or feedback about your experience as a member of this team, please reach out to Altered Beef, Rattle, or a team member you feel comfortable dialoguing with. 
+4. You agree to protect the artistic and financial interests of the band and associated acts by not publicly distributing leaked or unauthorized materials.
+5. Remember that everyone here is a volunteer, sharing their time, talent, and expertise, because just like you, they love this amazing band and what it stands for. Respect, both for yourself and for one another, is paramount.
+6. To riff on something the band projects before their concerts: Look after each other in here.
+7. If you have concerns, questions, or feedback about your experience as a member of this team, please reach out to Altered Beef, Rattle, or a team member you feel comfortable dialoguing with.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 1. Keep it fun. We're doing serious, at times painstaking, work to make the site incredible, but we can have fun in the process. Summon your best self. Bring a smile.
 2. Differences of opinion are bound to arise. Always give the benefit of the doubt and proceed with kindness. (To put it another way, “Take the high road.”)
-3. Maintain professionalism with one another, the wider KGLW fan community, and members of the band’s organization. Express agreement from team leaders is required when utilizing the kglw.net namesake in community or band outreach.
-4. You agree to protect the artistic and financial interests of the band and associated acts by not publicly distributing leaked or unauthorized materials.
+3. Maintain professionalism with one another, the wider King Gizzard fan community, and members of the band’s organization. It is required to receive explicit agreement from team leaders before using the KGLW.net name in community or band outreach.
+4. You agree to protect the artistic and financial interests of the band (and associated acts) by not associating the KGLW.net name with leaks or unauthorized materials.
 5. Remember that everyone here is a volunteer, sharing their time, talent, and expertise, because just like you, they love this amazing band and what it stands for. Respect, both for yourself and for one another, is paramount.
 6. To riff on something the band projects before their concerts: Look after each other in here.
 7. If you have concerns, questions, or feedback about your experience as a member of this team, please reach out to Altered Beef, Rattle, or a team member you feel comfortable dialoguing with.


### PR DESCRIPTION
* adds a new entry at #4, addressing leaks of King Gizzard content before it is officially released
  * content of the new entry: "You agree to protect the artistic and financial interests of the band (and associated acts) by not associating the KGLW.net name with leaks or unauthorized materials."
* [wording tweaks to #3](https://github.com/kglw-dot-net/.github/pull/1#discussion_r2076605073)
  * "KGLW fan community" ⇒ "King Gizzard fan community"
  * "Express agreement from team leaders is required when utilizing the kglw.net namesake" ⇒ "It is required to receive explicit agreement from team leaders before using the KGLW.net name"
* adjusts the markup to preserve numbering but make changes easier to parse in the future
  * in the `.md` file, every entry is numbered with "1." but when it is [displayed in GitHub](https://github.com/kglw-dot-net/.github/blob/main/CODE_OF_CONDUCT.md) (or another Markdown viewer) it will render with incrementing numbers as expected.